### PR TITLE
feat: reorganize packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check Formatting
-        run: cargo fmt -p near-sdk-abi -p near-sdk-abi-macros -- --check
+        run: cargo fmt -p near-sdk-abi -p near-sdk-abi-macros -p near-sdk-abi-impl -- --check
 
       - name: Check Clippy
-        run: cargo clippy -p near-sdk-abi -p near-sdk-abi-macros --tests -- -Dclippy::all
+        run: cargo clippy -p near-sdk-abi -p near-sdk-abi-macros -p near-sdk-abi-impl --tests -- -Dclippy::all
 
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  msrv-check:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Get MSRV
+        run: |
+          RUST_MSRV="$(cat near-sdk-abi/Cargo.toml | sed -n 's/rust-version *= *"\(.*\)"/\1/p')"
+          echo "RUST_MSRV=$RUST_MSRV" >> $GITHUB_ENV
+
+      - name: "Install ${{ env.RUST_MSRV }} toolchain (MSRV)"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_MSRV }}
+
+      - name: Cargo check
+        run: cargo check -p near-sdk-abi
+
+  tests:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Install `wasm32-unknown-unknown`
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Run tests
+        run: cargo test --workspace --verbose
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Check Formatting
+        run: cargo fmt -p near-sdk-abi -p near-sdk-abi-macros -- --check
+
+      - name: Check Clippy
+        run: cargo clippy -p near-sdk-abi -p near-sdk-abi-macros --tests -- -Dclippy::all
+
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Install Audit Tool
+        run: cargo install cargo-audit
+
+      - name: Run Audit Tool
+        run: cargo audit --ignore RUSTSEC-2020-0071

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "near-sdk-abi",
+    "near-sdk-abi-impl",
     "near-sdk-abi-macros",
     "examples/*"
 ]

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
+near-sdk = { version = "4.1.0", features = ["abi"] }
 near-sdk-abi = { path = "../../near-sdk-abi" }
 serde = "1.0"
 

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.0-pre.1", features = ["abi"] }
+near-sdk = { version = "4.1.0", features = ["abi"] }
 near-sdk-abi = { path = "../../near-sdk-abi" }
 serde = "1.0"
 

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = { version = "4.1.0-pre.1", features = ["abi"] }
-near-sdk-abi-macros = { path = "../../near-sdk-abi-macros" }
+near-sdk-abi = { path = "../../near-sdk-abi" }
 serde = "1.0"
 
 [dev-dependencies]

--- a/examples/delegator-macro/src/lib.rs
+++ b/examples/delegator-macro/src/lib.rs
@@ -1,6 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::near_bindgen;
-use near_sdk_abi_macros::near_abi_ext;
+use near_sdk_abi::near_abi_ext;
 
 near_abi_ext! { mod ext_adder trait Adder for "src/adder.json" }
 

--- a/near-sdk-abi-impl/Cargo.toml
+++ b/near-sdk-abi-impl/Cargo.toml
@@ -7,9 +7,6 @@ readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"
 
 [dependencies]
-anyhow = "1.0"
-convert_case = "0.5"
-prettyplease = "0.1"
 proc-macro2 = "1.0"
 schemafy_lib = { git = "https://github.com/near/schemafy", rev = "4fc8de1ef94f66db1f45889feebb9cf6b931dd94" }
 schemars = "0.8"

--- a/near-sdk-abi-impl/Cargo.toml
+++ b/near-sdk-abi-impl/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name = "near-sdk-abi"
+name = "near-sdk-abi-impl"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"
@@ -19,5 +18,3 @@ syn = "1.0"
 quote = "1.0"
 
 near-abi = "0.3.0"
-near-sdk-abi-impl = { path = "../near-sdk-abi-impl" }
-near-sdk-abi-macros = { path = "../near-sdk-abi-macros" }

--- a/near-sdk-abi-impl/src/lib.rs
+++ b/near-sdk-abi-impl/src/lib.rs
@@ -1,8 +1,7 @@
-use std::path::{Path, PathBuf};
-
 use near_abi::{AbiParameters, AbiRoot, AbiType};
 use quote::{format_ident, quote};
 use schemafy_lib::{Expander, Generator};
+use std::path::{Path, PathBuf};
 
 pub fn generate_ext(
     near_abi: AbiRoot,

--- a/near-sdk-abi-macros/Cargo.toml
+++ b/near-sdk-abi-macros/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/near/near-sdk-abi"
 proc-macro = true
 
 [dependencies]
-near-sdk-abi = { path = "../near-sdk-abi" }
 proc-macro2 = "1.0"
 syn = "1.0"
 quote = "1.0"
+
+near-sdk-abi-impl = { path = "../near-sdk-abi-impl" }

--- a/near-sdk-abi-macros/src/lib.rs
+++ b/near-sdk-abi-macros/src/lib.rs
@@ -1,4 +1,4 @@
-use near_sdk_abi::__private::{generate_ext, read_abi};
+use near_sdk_abi_impl::{generate_ext, read_abi};
 use std::path::PathBuf;
 
 #[proc_macro]

--- a/near-sdk-abi/Cargo.toml
+++ b/near-sdk-abi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "near-sdk-abi"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"

--- a/near-sdk-abi/Cargo.toml
+++ b/near-sdk-abi/Cargo.toml
@@ -11,10 +11,6 @@ repository = "https://github.com/near/near-sdk-abi"
 anyhow = "1.0"
 convert_case = "0.5"
 prettyplease = "0.1"
-proc-macro2 = "1.0"
-schemafy_lib = { git = "https://github.com/near/schemafy", rev = "4fc8de1ef94f66db1f45889feebb9cf6b931dd94" }
-schemars = "0.8"
-serde_json = "1.0"
 syn = "1.0"
 quote = "1.0"
 

--- a/near-sdk-abi/src/lib.rs
+++ b/near-sdk-abi/src/lib.rs
@@ -1,16 +1,13 @@
-use __private::{generate_ext, read_abi};
 use anyhow::{anyhow, Result};
 use convert_case::{Case, Casing};
+use near_sdk_abi_impl::{generate_ext, read_abi};
 use quote::{format_ident, quote};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs};
 
-// Private functions shared between macro & generation APIs, not stable to be used.
-#[doc(hidden)]
-#[path = "private/mod.rs"]
-pub mod __private;
+pub use near_sdk_abi_macros::near_abi_ext;
 
 pub struct AbiFile {
     /// Path to the ABI JSON file.


### PR DESCRIPTION
This PR moves common implementation sections to `near-sdk-abi-impl` in the same fashion to how it is done in https://github.com/near/near-abi-client-rs. `near-sdk-abi` exposes both generation and macro-driven APIs.