### PR TITLE
chore: upgrade to Rust edition 2024

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    # time has a DoS vulnerability (stack exhaustion), fixed in 0.3.47+ which requires Rust 1.88
+    # TODO(nearcore#15026): Remove this when rust-toolchain.toml is updated to >= 1.88
+    "RUSTSEC-2026-0009",
+]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,6 @@
 [advisories]
 ignore = [
+    "RUSTSEC-2020-0071",
     # time has a DoS vulnerability (stack exhaustion), fixed in 0.3.47+ which requires Rust 1.88
     # TODO(nearcore#15026): Remove this when rust-toolchain.toml is updated to >= 1.88
     "RUSTSEC-2026-0009",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,13 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
 
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup override set stable
+
       - name: Install Audit Tool
         run: cargo install cargo-audit
 
       - name: Run Audit Tool
-        run: cargo audit --ignore RUSTSEC-2020-0071
+        run: cargo audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 members = [
     "near-sdk-abi",
     "near-sdk-abi-impl",
-    "near-sdk-abi-macros",
-    "examples/*"
+    "near-sdk-abi-macros"
 ]
 resolver = "3"
+
+[patch.crates-io]
+parity-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", rev = "e84dd6bc611c3a9fa8ead4fc31fc6bfcf2b8b9ee" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = [
     "near-sdk-abi-macros",
     "examples/*"
 ]
+resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,11 @@
 members = [
     "near-sdk-abi",
     "near-sdk-abi-impl",
-    "near-sdk-abi-macros"
+    "near-sdk-abi-macros",
+    "examples/*",
 ]
 resolver = "3"
 
-[patch.crates-io]
-parity-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", rev = "e84dd6bc611c3a9fa8ead4fc31fc6bfcf2b8b9ee" }
+# [patch.crates-io]
+# parity-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", rev = "e84dd6bc611c3a9fa8ead4fc31fc6bfcf2b8b9ee" }
+

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "delegator-generation"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.86.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -8,14 +8,15 @@ rust-version = "1.86.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.0", features = ["abi"] }
+near-sdk = { version = "5.24.0", features = ["abi"] }
 near-sdk-abi = { path = "../../near-sdk-abi" }
 serde = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.7.0"
+near-workspaces = "0.22"
+near-sdk = { version = "5.24.0", features = ["abi", "unit-testing"] }
 
 [build-dependencies]
 anyhow = "1.0"

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "delegator-generation"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/delegator-generation/src/lib.rs
+++ b/examples/delegator-generation/src/lib.rs
@@ -1,4 +1,4 @@
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::near_bindgen;
 
 #[path = "../gen/adder.rs"]
@@ -6,6 +6,7 @@ mod adder;
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "near_sdk::borsh")]
 pub struct Delegator {}
 
 #[near_bindgen]

--- a/examples/delegator-generation/tests/workspaces.rs
+++ b/examples/delegator-generation/tests/workspaces.rs
@@ -1,18 +1,18 @@
-use workspaces::{Contract, DevNetwork, Worker};
+use near_workspaces::{Contract, DevNetwork, Worker};
 
 async fn init(worker: &Worker<impl DevNetwork>) -> anyhow::Result<(Contract, Contract)> {
     let adder = worker
-        .dev_deploy(&include_bytes!("../res/adder.wasm").to_vec())
+        .dev_deploy(include_bytes!("../res/adder.wasm"))
         .await?;
     let delegator = worker
-        .dev_deploy(&include_bytes!("../res/delegator_generation.wasm").to_vec())
+        .dev_deploy(include_bytes!("../res/delegator_generation.wasm"))
         .await?;
     Ok((adder, delegator))
 }
 
 #[tokio::test]
 async fn test_delegate() -> anyhow::Result<()> {
-    let worker = workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox().await?;
     let (adder, delegator) = init(&worker).await?;
 
     let res = delegator

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "delegator-macro"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "delegator-macro"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.86.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -8,11 +8,12 @@ rust-version = "1.86.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.0", features = ["abi"] }
+near-sdk = { version = "5.24.0", features = ["abi"] }
 near-sdk-abi = { path = "../../near-sdk-abi" }
 serde = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.7.0"
+near-workspaces = "0.22.0"
+near-sdk = { version = "5.24.0", features = ["abi", "unit-testing"] }

--- a/examples/delegator-macro/src/lib.rs
+++ b/examples/delegator-macro/src/lib.rs
@@ -1,4 +1,4 @@
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::near_bindgen;
 use near_sdk_abi::near_abi_ext;
 
@@ -6,6 +6,7 @@ near_abi_ext! { mod ext_adder trait Adder for "src/adder.json" }
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "near_sdk::borsh")]
 pub struct Delegator {}
 
 #[near_bindgen]

--- a/examples/delegator-macro/tests/workspaces.rs
+++ b/examples/delegator-macro/tests/workspaces.rs
@@ -1,18 +1,18 @@
-use workspaces::{Contract, DevNetwork, Worker};
+use near_workspaces::{Contract, DevNetwork, Worker};
 
 async fn init(worker: &Worker<impl DevNetwork>) -> anyhow::Result<(Contract, Contract)> {
     let adder = worker
-        .dev_deploy(&include_bytes!("../res/adder.wasm").to_vec())
+        .dev_deploy(include_bytes!("../res/adder.wasm"))
         .await?;
     let delegator = worker
-        .dev_deploy(&include_bytes!("../res/delegator_macro.wasm").to_vec())
+        .dev_deploy(include_bytes!("../res/delegator_macro.wasm"))
         .await?;
     Ok((adder, delegator))
 }
 
 #[tokio::test]
 async fn test_delegate() -> anyhow::Result<()> {
-    let worker = workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox().await?;
     let (adder, delegator) = init(&worker).await?;
 
     let res = delegator

--- a/near-sdk-abi-impl/Cargo.toml
+++ b/near-sdk-abi-impl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "near-sdk-abi-impl"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"
@@ -12,9 +13,9 @@ Utility library for making typesafe cross-contract calls in NEAR SDK smart contr
 [dependencies]
 proc-macro2 = "1.0"
 near_schemafy_lib = "0.7"
-schemars = "0.8"
+schemars = "0.8.8"
 serde_json = "1.0"
 syn = "1.0"
 quote = "1.0"
 
-near-abi = "0.3.0"
+near-abi = "0.4.0"

--- a/near-sdk-abi-impl/Cargo.toml
+++ b/near-sdk-abi-impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "near-sdk-abi-impl"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"

--- a/near-sdk-abi-impl/src/lib.rs
+++ b/near-sdk-abi-impl/src/lib.rs
@@ -94,7 +94,6 @@ pub fn get_crate_root() -> std::io::Result<PathBuf> {
 
     for p in current_dir.ancestors() {
         if std::fs::read_dir(p)?
-            .into_iter()
             .filter_map(Result::ok)
             .any(|p| p.file_name().eq("Cargo.toml"))
         {

--- a/near-sdk-abi-macros/Cargo.toml
+++ b/near-sdk-abi-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "near-sdk-abi-macros"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"

--- a/near-sdk-abi-macros/Cargo.toml
+++ b/near-sdk-abi-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "near-sdk-abi-macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"

--- a/near-sdk-abi/Cargo.toml
+++ b/near-sdk-abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "near-sdk-abi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/near-sdk-abi/Cargo.toml
+++ b/near-sdk-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "near-sdk-abi"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.56.0"
+rust-version = "1.86.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-sdk-abi"
@@ -17,6 +17,6 @@ prettyplease = "0.1"
 syn = "1.0"
 quote = "1.0"
 
-near-abi = "0.3.0"
+near-abi = "0.4.0"
 near-sdk-abi-impl = { path = "../near-sdk-abi-impl", version = "0.1" }
 near-sdk-abi-macros = { path = "../near-sdk-abi-macros", version = "0.1" }

--- a/near-sdk-abi/src/lib.rs
+++ b/near-sdk-abi/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use convert_case::{Case, Casing};
 use near_sdk_abi_impl::{generate_ext, read_abi};
 use quote::{format_ident, quote};

--- a/res/adder.json
+++ b/res/adder.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.3.0",
+  "schema_version": "0.4.0",
   "metadata": {
     "name": "abi",
     "version": "0.1.0",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.86"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Updates all crates in the workspace to Rust edition 2024 with resolver v3.